### PR TITLE
Support Mono compilation

### DIFF
--- a/PassiveSkillTreePlanter.csproj
+++ b/PassiveSkillTreePlanter.csproj
@@ -103,7 +103,7 @@
   </Target>
   <Target Name="AfterBuild">
     <ItemGroup>
-      <Textures Include="$(ProjectDri)textures\*.png"/>
+      <Textures Include="$(ProjectDri)textures\*"/>
     </ItemGroup>
     <Copy
       SourceFiles="@(Textures)"

--- a/PassiveSkillTreePlanter.csproj
+++ b/PassiveSkillTreePlanter.csproj
@@ -98,13 +98,18 @@
     </PreBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
-    <PostBuildEvent>XCOPY "$(ProjectDir)textures" "$(TargetDir)textures" /s /i /y</PostBuildEvent>
   </PropertyGroup>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>
   <Target Name="AfterBuild">
+    <ItemGroup>
+      <Textures Include="$(ProjectDri)textures\*.png"/>
+    </ItemGroup>
+    <Copy
+      SourceFiles="@(Textures)"
+      DestinationFolder="$(TargetDir)..\..\..\PoeHelper\Plugins\Compiled\PassiveSkillTreePlanter\textures"
+      SkipUnchangedFiles="true"
+      OverwriteReadOnlyFiles="true"
+    />
   </Target>
-  -->
 </Project>

--- a/PassiveSkillTreePlanter.csproj
+++ b/PassiveSkillTreePlanter.csproj
@@ -27,7 +27,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>..\..\..\..\PoEHelper\Plugins\Compiled\PassiveSkillTreePlanter\</OutputPath>
+    <OutputPath>..\..\..\..\PoeHelper\Plugins\Compiled\PassiveSkillTreePlanter\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -36,23 +36,23 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="ImGui.NET">
-      <HintPath>..\..\..\..\PoEHelper\ImGui.NET.dll</HintPath>
+      <HintPath>..\..\..\..\PoeHelper\ImGui.NET.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\..\..\PoEHelper\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\..\..\PoeHelper\Newtonsoft.Json.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Serilog">
-      <HintPath>..\..\..\..\PoEHelper\Serilog.dll</HintPath>
+      <HintPath>..\..\..\..\PoeHelper\Serilog.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="SharpDX">
-      <HintPath>..\..\..\..\PoEHelper\SharpDX.dll</HintPath>
+      <HintPath>..\..\..\..\PoeHelper\SharpDX.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="SharpDX.Mathematics">
-      <HintPath>..\..\..\..\PoEHelper\SharpDX.Mathematics.dll</HintPath>
+      <HintPath>..\..\..\..\PoeHelper\SharpDX.Mathematics.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />


### PR DESCRIPTION
This commit changes references to `PoEHelper` to `PoeHelper` to streamline and conform with other plugins.

I've also changed the PostBuildEvent to be a os-agnostic way of copying the textures instead of relying on `XCOPY` (cmd.exe).